### PR TITLE
User information is not always taken

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/google/go-github/v24/github"
-	"golang.org/x/oauth2"
 	"log"
 	"net/http"
+
+	"github.com/google/go-github/v24/github"
+	"golang.org/x/oauth2"
 )
 
 func Start(baseUrl string, uploadUrl string, org string) error {
@@ -31,6 +32,10 @@ func Start(baseUrl string, uploadUrl string, org string) error {
 		user, err := getUserInfo(baseUrl, areq.Spec.Token)
 		if err != nil {
 			http.Error(rw, fmt.Sprintf("Failed to get user info: %s", err.Error()), 401)
+		}
+
+		if user.Login == nil {
+			http.Error(rw, "Failed to get user info", 401)
 		}
 
 		client, err := github.NewEnterpriseClient(baseUrl, uploadUrl, tc)


### PR DESCRIPTION
Hi Ryosan!

I got the following event.
```
2019/08/21 02:50:01 server.go:3012: http: panic serving 10.233.65.0:50692: runtime error: invalid memory address or nil pointer dereference
goroutine 19929 [running]:
net/http.(*conn).serve.func1(0xc00025b4a0)
        /usr/local/go/src/net/http/server.go:1769 +0xc9
panic(0x826c20, 0xc6b9f0)
        /usr/local/go/src/runtime/panic.go:522 +0x1b5
github.com/takaishi/k8s-github-auth/server.Start.func1(0x953c80, 0xc000368540, 0xc0002bca00)
        /go/src/github.com/takaishi/k8s-github-auth/server/server.go:51 +0x3a1
net/http.HandlerFunc.ServeHTTP(0xc0000a0540, 0x953c80, 0xc000368540, 0xc0002bca00)
        /usr/local/go/src/net/http/server.go:1995 +0x44
net/http.(*ServeMux).ServeHTTP(0xc782c0, 0x953c80, 0xc000368540, 0xc0002bca00)
        /usr/local/go/src/net/http/server.go:2375 +0x1d6
net/http.serverHandler.ServeHTTP(0xc00006add0, 0x953c80, 0xc000368540, 0xc0002bca00)
        /usr/local/go/src/net/http/server.go:2774 +0xab
net/http.(*conn).serve(0xc00025b4a0, 0x9546c0, 0xc00004e840)
        /usr/local/go/src/net/http/server.go:1878 +0x84c
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:2884 +0x2f4
```

I think that oAuth Request can't always return user login info, that's why I added check return  login info after oAuth Requst.

Thanks.