### PR TITLE
Cache Github API server responses to improve performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV PATH=$GOPATH/bin:$PATH
 ENV CGO_ENABLED 0
 ENV GO111MODULE on
 
+RUN apt update -y && apt upgrade -y ca-certificates
 RUN mkdir -p /go/{src,bin,pkg}
 
 ADD . /go/src/github.com/takaishi/k8s-github-auth

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/takaishi/k8s-github-auth
 
 require (
 	github.com/google/go-github/v24 v24.0.0
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/urfave/cli v1.20.0
 	golang.org/x/oauth2 v0.0.0-20190212230446-3e8b2be13635

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/takaishi/k8s-github-auth
 
 require (
+	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/go-github/v24 v24.0.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/urfave/cli v1.20.0
 	golang.org/x/oauth2 v0.0.0-20190212230446-3e8b2be13635
 	gopkg.in/square/go-jose.v2 v2.5.1

--- a/server/server.go
+++ b/server/server.go
@@ -136,7 +136,11 @@ func getUserInfo(github_base_url string, token string) (github.User, error) {
 }
 
 func (c *GHEClient) getTeams(ctx context.Context) (map[string][]string, error) {
-	cacheKey := fmt.Sprintf("%s-teams", ctx.Value("token"))
+	token, ok := ctx.Value("token").(string)
+	if !ok {
+		return map[string][]string{}, fmt.Errorf("token not found")
+	}
+	cacheKey := fmt.Sprintf("%s-teams", token)
 	cacheResult, found := cache.Get(cacheKey)
 	if found {
 		log.Println("[DEBUG] cache hit getTeams")
@@ -169,11 +173,7 @@ func (c *GHEClient) getTeams(ctx context.Context) (map[string][]string, error) {
 		resp[*team.Organization.Login] = append(resp[*team.Organization.Login], *team.Name)
 	}
 
-	if cacheKey != "-teams" {
-		cache.Set(cacheKey, resp, 10*time.Minute)
-	} else {
-		log.Println("getTeams: invalid cache key")
-	}
+	cache.Set(cacheKey, resp, 10*time.Minute)
 
 	return resp, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -37,7 +37,6 @@ func (c *GHEClient) Login(ctx context.Context, token string) error {
 	if err != nil {
 		return err
 	}
-	ctx = context.WithValue(ctx, "token", token)
 	c.client = client
 
 	return nil
@@ -212,6 +211,9 @@ func checkToken(baseUrl string, uploadUrl string, org string, req *http.Request)
 	if err != nil {
 		return user, teams, fmt.Errorf("Failed to login to GHE: %s", err.Error())
 	}
+
+	ctx := context.WithValue(req.Context(), "token", areq.Spec.Token)
+	req = req.WithContext(ctx)
 
 	teams, err = gheClient.getTeams(req.Context())
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -26,7 +26,6 @@ type GHEClient struct {
 	baseURL   string
 	uploadURL string
 	client    *github.Client
-	token     string
 }
 
 func (c *GHEClient) Login(ctx context.Context, token string) error {
@@ -38,7 +37,7 @@ func (c *GHEClient) Login(ctx context.Context, token string) error {
 	if err != nil {
 		return err
 	}
-	c.token = token
+	context.WithValue(ctx, "token", token)
 	c.client = client
 
 	return nil
@@ -137,7 +136,7 @@ func getUserInfo(github_base_url string, token string) (github.User, error) {
 }
 
 func (c *GHEClient) getTeams(ctx context.Context) (map[string][]string, error) {
-	cacheKey := fmt.Sprintf("%s-teams", c.token)
+	cacheKey := fmt.Sprintf("%s-teams", ctx.Value("token"))
 	cacheResult, found := cache.Get(cacheKey)
 	if found {
 		log.Printf("[DEBUG] cache hit value: %+v", cacheResult)

--- a/server/server.go
+++ b/server/server.go
@@ -37,7 +37,7 @@ func (c *GHEClient) Login(ctx context.Context, token string) error {
 	if err != nil {
 		return err
 	}
-	context.WithValue(ctx, "token", token)
+	ctx = context.WithValue(ctx, "token", token)
 	c.client = client
 
 	return nil

--- a/server/server.go
+++ b/server/server.go
@@ -169,7 +169,11 @@ func (c *GHEClient) getTeams(ctx context.Context) (map[string][]string, error) {
 		resp[*team.Organization.Login] = append(resp[*team.Organization.Login], *team.Name)
 	}
 
-	cache.Set(cacheKey, resp, 10*time.Minute)
+	if cacheKey != "-teams" {
+		cache.Set(cacheKey, resp, 10*time.Minute)
+	} else {
+		log.Println("getTeams: invalid cache key")
+	}
 
 	return resp, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -5,13 +5,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/google/go-github/v24/github"
-	"golang.org/x/oauth2"
-	"gopkg.in/square/go-jose.v2/jwt"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"time"
+
+	"github.com/google/go-github/v24/github"
+	gocache "github.com/patrickmn/go-cache"
+	"golang.org/x/oauth2"
+	"gopkg.in/square/go-jose.v2/jwt"
 )
+
+var cache = gocache.New(60*time.Minute, 90*time.Minute)
 
 func NewGHEClient(baseURL, uploadURL string) *GHEClient {
 	return &GHEClient{baseURL: baseURL, uploadURL: uploadURL}
@@ -21,6 +26,7 @@ type GHEClient struct {
 	baseURL   string
 	uploadURL string
 	client    *github.Client
+	token     string
 }
 
 func (c *GHEClient) Login(ctx context.Context, token string) error {
@@ -32,6 +38,7 @@ func (c *GHEClient) Login(ctx context.Context, token string) error {
 	if err != nil {
 		return err
 	}
+	c.token = token
 	c.client = client
 
 	return nil
@@ -92,6 +99,13 @@ func Start(baseUrl string, uploadUrl string, org string) error {
 }
 
 func getUserInfo(github_base_url string, token string) (github.User, error) {
+	cacheKey := fmt.Sprintf("%s-user", token)
+	cacheResult, found := cache.Get(cacheKey)
+	if found {
+		log.Printf("[DEBUG] cache hit value: %+v", cacheResult)
+		return cacheResult.(github.User), nil
+	}
+
 	var u github.User
 	req, _ := http.NewRequest("GET", github_base_url+"/user", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -117,10 +131,19 @@ func getUserInfo(github_base_url string, token string) (github.User, error) {
 		return u, err
 	}
 
+	cache.Set(cacheKey, u, gocache.DefaultExpiration)
+
 	return u, nil
 }
 
 func (c *GHEClient) getTeams(ctx context.Context) (map[string][]string, error) {
+	cacheKey := fmt.Sprintf("%s-teams", c.token)
+	cacheResult, found := cache.Get(cacheKey)
+	if found {
+		log.Printf("[DEBUG] cache hit value: %+v", cacheResult)
+		return cacheResult.(map[string][]string), nil
+	}
+
 	listOpt := &github.ListOptions{
 		PerPage: 100,
 	}
@@ -146,6 +169,8 @@ func (c *GHEClient) getTeams(ctx context.Context) (map[string][]string, error) {
 		}
 		resp[*team.Organization.Login] = append(resp[*team.Organization.Login], *team.Name)
 	}
+
+	cache.Set(cacheKey, resp, 10*time.Minute)
 
 	return resp, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -101,7 +101,7 @@ func getUserInfo(github_base_url string, token string) (github.User, error) {
 	cacheKey := fmt.Sprintf("%s-user", token)
 	cacheResult, found := cache.Get(cacheKey)
 	if found {
-		log.Printf("[DEBUG] cache hit value: %+v", cacheResult)
+		log.Println("[DEBUG] cache hit getUserInfo")
 		return cacheResult.(github.User), nil
 	}
 
@@ -139,7 +139,7 @@ func (c *GHEClient) getTeams(ctx context.Context) (map[string][]string, error) {
 	cacheKey := fmt.Sprintf("%s-teams", ctx.Value("token"))
 	cacheResult, found := cache.Get(cacheKey)
 	if found {
-		log.Printf("[DEBUG] cache hit value: %+v", cacheResult)
+		log.Println("[DEBUG] cache hit getTeams")
 		return cacheResult.(map[string][]string), nil
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -212,10 +212,7 @@ func checkToken(baseUrl string, uploadUrl string, org string, req *http.Request)
 		return user, teams, fmt.Errorf("Failed to login to GHE: %s", err.Error())
 	}
 
-	ctx := context.WithValue(req.Context(), "token", areq.Spec.Token)
-	req = req.WithContext(ctx)
-
-	teams, err = gheClient.getTeams(req.Context())
+	teams, err = gheClient.getTeams(context.WithValue(req.Context(), "token", areq.Spec.Token))
 	if err != nil {
 		return user, teams, fmt.Errorf("Failed to get teams: %s", err.Error())
 	}


### PR DESCRIPTION
Hi!

Cache username and teams with token as key to improve performance.

GitHub teams is subject to change, so I've set it to a shorter TTL


- Operation check 
  - Confirmed to cache with 2 or more requests
  ```
  k8s-github-auth-6698ff5566-fgzjq k8s-github-auth 2022/02/04 10:27:21 server.go:103: [DEBUG] cache hit getUserInfo
  k8s-github-auth-6698ff5566-fgzjq k8s-github-auth 2022/02/04 10:27:21 server.go:145: [DEBUG] cache hit getTeams
  k8s-github-auth-6698ff5566-fgzjq k8s-github-auth 2022/02/04 10:27:21 server.go:87: [DEBUG] &{ApiVersion:authentication.k8s.io/v1beta1 Kind:TokenReview Status:{Authenticated:true ..
  ```
  - Confirmed that requests for different tokens are generated as different caches