### PR TITLE
areq をログに出すと token が露出するので削除する

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -196,7 +196,6 @@ func checkToken(baseUrl string, uploadUrl string, org string, req *http.Request)
 		return user, teams, errors.New("token is unsupported format (JWT).")
 	}
 
-	fmt.Printf("[DEBUG] areq: %+v\n", areq)
 	user, err = getUserInfo(baseUrl, areq.Spec.Token)
 	if err != nil {
 		return user, teams, errors.New(fmt.Sprintf("Failed to get user info: %s", err.Error()))


### PR DESCRIPTION
areq.Spec.Token がマスクされずにログに出るので削除します。
現状ここに入ってくるログに情報量はないため、削除して問題ないと思います。

```
 [DEBUG] areq: {ApiVersion:authentication.k8s.io/v1beta1 Kind:TokenReview Metadata:map[creationTimestamp:<nil>] Spec:{Token:******} Status:{User:map[]}}
```